### PR TITLE
#146366313 Missing link to compare_reduction.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,7 @@ install: source build_tools/travis/install.sh
 script: bash build_tools/travis/test_script.sh
 after_success: source build_tools/travis/after_success.sh
 notifications:
+  slack: andela:G6s38o91RuZQsbgx72QvPPll
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/4ffabb4df010b70cd624

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,9 @@
 
 |Travis|_ |AppVeyor|_ |Codecov|_ |CircleCI|_ |Python27|_ |Python35|_ |PyPi|_ |DOI|_
 
-.. |Travis| image:: https://api.travis-ci.org/scikit-learn/scikit-learn.svg?branch=master
-.. _Travis: https://travis-ci.org/scikit-learn/scikit-learn
+
+.. |Travis| image:: https://travis-ci.org/andela/boomslang-scikit-learn.svg?branch=master
+.. _Travis: https://travis-ci.org/andela/boomslang-scikit-learn
 
 .. |AppVeyor| image:: https://ci.appveyor.com/api/projects/status/github/scikit-learn/scikit-learn?branch=master&svg=true
 .. _AppVeyor: https://ci.appveyor.com/project/sklearn-ci/scikit-learn/history
@@ -168,3 +169,5 @@ Citation
 ~~~~~~~~
 
 If you use scikit-learn in a scientific publication, we would appreciate citations: http://scikit-learn.org/stable/about.html#citing-scikit-learn
+ 
+ 

--- a/doc/whats_new.rst
+++ b/doc/whats_new.rst
@@ -780,7 +780,7 @@ Model evaluation and meta-estimators
    - Added support for substituting or disabling :class:`pipeline.Pipeline`
      and :class:`pipeline.FeatureUnion` components using the ``set_params``
      interface that powers :mod:`sklearn.grid_search`.
-     See :ref:`sphx_glr_plot_compare_reduction.py`. By `Joel Nothman`_ and
+     See :ref:`plot_compare_reduction.py`. By `Joel Nothman`_ and
      :user:`Robert McGibbon <rmcgibbo>`.
 
    - The new ``cv_results_`` attribute of :class:`model_selection.GridSearchCV`


### PR DESCRIPTION
#### What does this PR do?
Adds link to compare_reducition.py in whats_new.rst
#### Description of Task to be completed?
open boomslang-sckit-learn/doc/whats_new.rst
Edit the link from sphx_glr_plot_compare_reduction.py to compare_reduction.py
#### How should this be manually tested?
Follow the link indicated, the earlier provided one doesn't exist
#### Any background context you want to provide?
 https://github.com/scikit-learn/scikit-learn/issues/8885
#### What are the relevant pivotal tracker stories?
#146366313
