### PR TITLE
[Feature #146674903] Add 've' to english stop words

### DIFF
--- a/sklearn/feature_extraction/stop_words.py
+++ b/sklearn/feature_extraction/stop_words.py
@@ -42,4 +42,4 @@ ENGLISH_STOP_WORDS = frozenset([
     "wherein", "whereupon", "wherever", "whether", "which", "while", "whither",
     "who", "whoever", "whole", "whom", "whose", "why", "will", "with",
     "within", "without", "would", "yet", "you", "your", "yours", "yourself",
-    "yourselves"])
+    "yourselves", "ve"])


### PR DESCRIPTION
#### What does this PR do?
Adds 've' to the the english stop words frozenset
#### Description of Task to be completed?
open [https://github.com/andela/boomslang-scikit-learn/blob/master/sklearn/feature_extraction/stop_words.py](url) and 've' to the ENGLISH_STOP_WORDS
#### How should this be manually tested?
[https://github.com/andela/boomslang-scikit-learn/blob/ft-english-stop-words-146674903/sklearn/feature_extraction/stop_words.py](url) 
#### Any background context you want to provide?
[https://github.com/scikit-learn/scikit-learn/issues/8687](url) scikit learn repo
#### What are the relevant pivotal tracker stories?
#146674903